### PR TITLE
Add gitConfigGet() and gitGetRepositoryUrl()

### DIFF
--- a/lib/assertEx.ts
+++ b/lib/assertEx.ts
@@ -134,4 +134,20 @@ export namespace assertEx {
     defined(expectedLowerBound, "expectedLowerBound");
     assert(value > expectedLowerBound, `${expressionName || "value"} (${value}) must be greater than ${expectedLowerBound}.`);
   }
+
+  /**
+   * Assert that the provided value is equal to one of the provided expectedValues.
+   * @param value The value to look for.
+   * @param expectedValues The expected values that value could be.
+   */
+  export function oneOf<T>(value: T, expectedValues: T[]): void {
+    let found = false;
+    for (const expectedValue of expectedValues) {
+      if (value === expectedValue) {
+        found = true;
+        break;
+      }
+    }
+    assert(found, `Expected ${value} to be one of the following values: ${JSON.stringify(expectedValues)}`);
+  }
 }

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -694,6 +694,37 @@ export async function gitStatus(options: RunOptions = {}): Promise<GitStatusResu
   };
 }
 
+/**
+ * The result of running gitGetConfig().
+ */
+export interface GitGetConfigResult extends GitRunResult {
+  /**
+   * The requested configuration value or undefined if the value was not found.
+   */
+  configurationValue?: string;
+}
+
+/**
+ * Get the configuration value for the provided configuration value name.
+ * @param configurationValueName The name of the configuration value to get.
+ * @param options The options that can configure how the command will run.
+ */
+export async function gitConfigGet(configurationValueName: string, options?: RunOptions): Promise<GitGetConfigResult> {
+  const result: GitGetConfigResult = await git(["config", "--get", configurationValueName], options);
+  if (result.exitCode === 0 && result.stdout) {
+    result.configurationValue = result.stdout;
+  }
+  return result;
+}
+
+/**
+ * Get the URL of the current repository.
+ * @param options The options that can configure how the command will run.
+ */
+export async function gitGetRepositoryUrl(options?: RunOptions): Promise<string | undefined> {
+  return (await gitConfigGet("remote.origin.url", options)).configurationValue;
+}
+
 export class GitScope {
   constructor(private options: RunOptions) {
   }
@@ -830,6 +861,29 @@ export class GitScope {
     return gitStatus({
       ...this.options,
       ...options,
+    });
+  }
+
+  /**
+   * Get the configuration value for the provided configuration value name.
+   * @param configurationValueName The name of the configuration value to get.
+   * @param options The options that can configure how the command will run.
+   */
+  public configGet(configurationValueName: string, options?: RunOptions): Promise<GitGetConfigResult> {
+    return gitConfigGet(configurationValueName, {
+      ...this.options,
+      ...options
+    });
+  }
+
+  /**
+   * Get the URL of the current repository.
+   * @param options The options that can configure how the command will run.
+   */
+  public getRepositoryUrl(options?: RunOptions): Promise<string | undefined> {
+    return gitGetRepositoryUrl({
+      ...this.options,
+      ...options
     });
   }
 }

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -722,7 +722,11 @@ export async function gitConfigGet(configurationValueName: string, options?: Run
  * @param options The options that can configure how the command will run.
  */
 export async function gitGetRepositoryUrl(options?: RunOptions): Promise<string | undefined> {
-  return (await gitConfigGet("remote.origin.url", options)).configurationValue;
+  let result: string | undefined = (await gitConfigGet("remote.origin.url", options)).configurationValue;
+  if (result) {
+    result = result.trimEnd();
+  }
+  return result;
 }
 
 export class GitScope {

--- a/lib/git.ts
+++ b/lib/git.ts
@@ -724,7 +724,7 @@ export async function gitConfigGet(configurationValueName: string, options?: Run
 export async function gitGetRepositoryUrl(options?: RunOptions): Promise<string | undefined> {
   let result: string | undefined = (await gitConfigGet("remote.origin.url", options)).configurationValue;
   if (result) {
-    result = result.trimEnd();
+    result = result.trim();
   }
   return result;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-common/azure-js-dev-tools",
-  "version": "13.8.1",
+  "version": "13.9.0",
   "description": "Developer dependencies for TypeScript related projects",
   "main": "./dist/lib/index.js",
   "types": "./dist/lib/index.d.ts",

--- a/test/gitTests.ts
+++ b/test/gitTests.ts
@@ -851,9 +851,9 @@ no changes added to commit (use "git add" and/or "git commit -a")`,
       assertEx.defined(result, "result");
       assert.strictEqual(result.exitCode, 0);
       assertEx.defined(result.processId, "result.processId");
-      assert.strictEqual(result.stdout, "https://github.com/ts-common/azure-js-dev-tools.git\n");
+      assertEx.oneOf(result.stdout, ["https://github.com/ts-common/azure-js-dev-tools.git\n", "https://github.com/ts-common/azure-js-dev-tools\n"]);
       assert.strictEqual(result.stderr, "");
-      assert.strictEqual(result.configurationValue, "https://github.com/ts-common/azure-js-dev-tools.git\n");
+      assertEx.oneOf(result.configurationValue, ["https://github.com/ts-common/azure-js-dev-tools.git\n", "https://github.com/ts-common/azure-js-dev-tools\n"]);
     });
 
     it("outside git repository", async function () {
@@ -878,7 +878,7 @@ no changes added to commit (use "git add" and/or "git commit -a")`,
 
     it("inside git repository", async function () {
       const result: string | undefined = await gitGetRepositoryUrl();
-      assert.strictEqual(result, "https://github.com/ts-common/azure-js-dev-tools.git");
+      assertEx.oneOf(result, ["https://github.com/ts-common/azure-js-dev-tools.git", "https://github.com/ts-common/azure-js-dev-tools"]);
     });
 
     it("outside git repository", async function () {

--- a/test/gitTests.ts
+++ b/test/gitTests.ts
@@ -878,7 +878,7 @@ no changes added to commit (use "git add" and/or "git commit -a")`,
 
     it("inside git repository", async function () {
       const result: string | undefined = await gitGetRepositoryUrl();
-      assert.strictEqual(result, "https://github.com/ts-common/azure-js-dev-tools.git\n");
+      assert.strictEqual(result, "https://github.com/ts-common/azure-js-dev-tools.git");
     });
 
     it("outside git repository", async function () {

--- a/test/gitTests.ts
+++ b/test/gitTests.ts
@@ -1,8 +1,8 @@
 import { assert } from "chai";
 import { joinPath } from "../lib";
 import { assertEx } from "../lib/assertEx";
-import { findFileInPathSync } from "../lib/fileSystem2";
-import { getGitRemoteBranch, getRemoteBranchFullName, git, gitAddAll, gitCheckout, gitClone, gitCommit, gitCreateLocalBranch, gitCurrentBranch, gitDeleteLocalBranch, gitDeleteRemoteBranch, gitDiff, GitDiffResult, gitFetch, gitLocalBranches, GitLocalBranchesResult, gitMergeOriginMaster, gitPull, gitPush, GitRemoteBranch, gitRemoteBranches, GitRemoteBranchesResult, GitRunResult, gitStatus, GitStatusResult } from "../lib/git";
+import { findFileInPath, findFileInPathSync } from "../lib/fileSystem2";
+import { getGitRemoteBranch, getRemoteBranchFullName, git, gitAddAll, gitCheckout, gitClone, gitCommit, gitConfigGet, gitCreateLocalBranch, gitCurrentBranch, gitDeleteLocalBranch, gitDeleteRemoteBranch, gitDiff, GitDiffResult, gitFetch, GitGetConfigResult as GitConfigGetResult, gitGetRepositoryUrl, gitLocalBranches, GitLocalBranchesResult, gitMergeOriginMaster, gitPull, gitPush, GitRemoteBranch, gitRemoteBranches, GitRemoteBranchesResult, GitRunResult, gitStatus, GitStatusResult } from "../lib/git";
 import { FakeRunner, RunResult } from "../lib/run";
 
 const runPushRemoteBranchTests: boolean = !!findFileInPathSync("github.auth");
@@ -804,6 +804,87 @@ no changes added to commit (use "git add" and/or "git commit -a")`,
           "/mock/folder/a/b.txt"
         ]
       });
+    });
+  });
+
+  describe("gitConfigGet()", function () {
+    it("command line arguments", async function () {
+      const runner = new FakeRunner();
+      const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
+      runner.set({ command: "git", args: ["config", "--get", "a"], result: expectedResult });
+      assert.deepEqual(await gitConfigGet("a", { runner }), expectedResult);
+    });
+
+    it("with undefined configurationValueName", async function () {
+      const result: GitConfigGetResult = await gitConfigGet(undefined as any);
+      assertEx.defined(result, "result");
+      assert.strictEqual(result.exitCode, 1);
+      assertEx.defined(result.processId, "result.processId");
+      assert.strictEqual(result.stdout, "");
+      assert.strictEqual(result.stderr, "error: key does not contain a section: undefined\n");
+      assert.strictEqual(result.configurationValue, undefined);
+    });
+
+    it("with null configurationValueName", async function () {
+      // tslint:disable-next-line:no-null-keyword
+      const result: GitConfigGetResult = await gitConfigGet(null as any);
+      assertEx.defined(result, "result");
+      assert.strictEqual(result.exitCode, 1);
+      assertEx.defined(result.processId, "result.processId");
+      assert.strictEqual(result.stdout, "");
+      assert.strictEqual(result.stderr, "error: key does not contain a section: null\n");
+      assert.strictEqual(result.configurationValue, undefined);
+    });
+
+    it("with non-existing configurationValueName", async function () {
+      const result: GitConfigGetResult = await gitConfigGet("blah");
+      assertEx.defined(result, "result");
+      assert.strictEqual(result.exitCode, 1);
+      assertEx.defined(result.processId, "result.processId");
+      assert.strictEqual(result.stdout, "");
+      assert.strictEqual(result.stderr, "error: key does not contain a section: blah\n");
+      assert.strictEqual(result.configurationValue, undefined);
+    });
+
+    it("with existing configurationValueName", async function () {
+      const result: GitConfigGetResult = await gitConfigGet("remote.origin.url");
+      assertEx.defined(result, "result");
+      assert.strictEqual(result.exitCode, 0);
+      assertEx.defined(result.processId, "result.processId");
+      assert.strictEqual(result.stdout, "https://github.com/ts-common/azure-js-dev-tools.git\n");
+      assert.strictEqual(result.stderr, "");
+      assert.strictEqual(result.configurationValue, "https://github.com/ts-common/azure-js-dev-tools.git\n");
+    });
+
+    it("outside git repository", async function () {
+      const folderPath: string = joinPath((await findFileInPath("package.json"))!, "../..");
+      const result: GitConfigGetResult = await gitConfigGet("remote.origin.url", { executionFolderPath: folderPath });
+      assertEx.defined(result, "result");
+      assert.strictEqual(result.exitCode, 1);
+      assertEx.defined(result.processId, "result.processId");
+      assert.strictEqual(result.stdout, "");
+      assert.strictEqual(result.stderr, "");
+      assert.strictEqual(result.configurationValue, undefined);
+    });
+  });
+
+  describe("gitGetRepositoryUrl()", function () {
+    it("command line arguments", async function () {
+      const runner = new FakeRunner();
+      const expectedResult: GitConfigGetResult = { exitCode: 2, stdout: "c", stderr: "d", configurationValue: "e" };
+      runner.set({ command: "git", args: ["config", "--get", "remote.origin.url"], result: expectedResult });
+      assert.deepEqual(await gitGetRepositoryUrl({ runner }), expectedResult.configurationValue);
+    });
+
+    it("inside git repository", async function () {
+      const result: string | undefined = await gitGetRepositoryUrl();
+      assert.strictEqual(result, "https://github.com/ts-common/azure-js-dev-tools.git\n");
+    });
+
+    it("outside git repository", async function () {
+      const folderPath: string = joinPath((await findFileInPath("package.json"))!, "../..");
+      const result: string | undefined = await gitGetRepositoryUrl({ executionFolderPath: folderPath });
+      assert.strictEqual(result, undefined);
     });
   });
 });

--- a/test/githubTests.ts
+++ b/test/githubTests.ts
@@ -2,7 +2,7 @@ import { assert } from "chai";
 import { assertEx } from "../lib/assertEx";
 import { writeFileContents } from "../lib/fileSystem2";
 import { GitScope } from "../lib/git";
-import { FakeGitHub, FakeGitHubRepository, getGitHubRepository, getRepositoryFullName, GitHub, GitHubComment, GitHubCommit, GitHubLabel, GitHubMilestone, GitHubPullRequest, GitHubPullRequestCommit, gitHubPullRequestGetAssignee, gitHubPullRequestGetLabel, gitHubPullRequestGetLabels, GitHubRepository, GitHubSprintLabel, GitHubUser, RealGitHub } from "../lib/github";
+import { FakeGitHub, FakeGitHubRepository, getGitHubRepository, getRepositoryFullName, GitHub, GitHubComment, GitHubCommit, GitHubLabel, GitHubMilestone, GitHubPullRequest, GitHubPullRequestCommit, gitHubPullRequestGetAssignee, gitHubPullRequestGetLabel, gitHubPullRequestGetLabels, GitHubRepository, GitHubSprintLabel, GitHubUser, RealGitHub, getGitHubRepositoryFromUrl } from "../lib/github";
 import { findPackageJsonFileSync } from "../lib/packageJson";
 import { getParentFolderPath, joinPath } from "../lib/path";
 import { contains } from "../lib/arrays";
@@ -260,6 +260,86 @@ describe("github.ts", function () {
       assert.deepEqual(repository.labels, []);
       assert.deepEqual(repository.milestones, []);
       assert.deepEqual(repository.pullRequests, []);
+    });
+  });
+
+  describe("getGitHubRepositoryFromUrl()", function () {
+    it("with undefined", function () {
+      assert.strictEqual(getGitHubRepositoryFromUrl(undefined as any), undefined);
+    });
+
+    it("with null", function () {
+      // tslint:disable-next-line:no-null-keyword
+      assert.strictEqual(getGitHubRepositoryFromUrl(null as any), undefined);
+    });
+
+    it(`with ""`, function () {
+      assert.strictEqual(getGitHubRepositoryFromUrl(""), undefined);
+    });
+
+    it(`with non-GitHub URL`, function () {
+      assert.strictEqual(getGitHubRepositoryFromUrl("https://www.bing.com/search?q=Kepler-47+third+planet"), undefined);
+    });
+
+    it(`with "https://github.com"`, function () {
+      assert.strictEqual(getGitHubRepositoryFromUrl("https://github.com"), undefined);
+    });
+
+    it(`with "https://github.com/"`, function () {
+      assert.strictEqual(getGitHubRepositoryFromUrl("https://github.com/"), undefined);
+    });
+
+    it(`with "https://github.com/.git"`, function () {
+      assert.strictEqual(getGitHubRepositoryFromUrl("https://github.com/.git"), undefined);
+    });
+
+    it(`with "https://github.com/hello"`, function () {
+      assert.deepEqual(getGitHubRepositoryFromUrl("https://github.com/hello"), {
+        organization: "",
+        name: "hello",
+      });
+    });
+
+    it(`with "https://github.com/hello.git"`, function () {
+      assert.deepEqual(getGitHubRepositoryFromUrl("https://github.com/hello.git"), {
+        organization: "",
+        name: "hello",
+      });
+    });
+
+    it(`with "https://github.com/hello/"`, function () {
+      assert.deepEqual(getGitHubRepositoryFromUrl("https://github.com/hello/"), {
+        organization: "",
+        name: "hello",
+      });
+    });
+
+    it(`with "https://github.com/Azure/azure-rest-api-specs"`, function () {
+      assert.deepEqual(getGitHubRepositoryFromUrl("https://github.com/Azure/azure-rest-api-specs"), {
+        organization: "Azure",
+        name: "azure-rest-api-specs",
+      });
+    });
+
+    it(`with "https://github.com/Azure/azure-rest-api-specs.git"`, function () {
+      assert.deepEqual(getGitHubRepositoryFromUrl("https://github.com/Azure/azure-rest-api-specs.git"), {
+        organization: "Azure",
+        name: "azure-rest-api-specs",
+      });
+    });
+
+    it(`with "https://github.com/ts-common/azure-js-dev-tools/blob/master/.gitignore"`, function () {
+      assert.deepEqual(getGitHubRepositoryFromUrl("https://github.com/ts-common/azure-js-dev-tools/blob/master/.gitignore"), {
+        organization: "ts-common",
+        name: "azure-js-dev-tools",
+      });
+    });
+
+    it(`with "https://github.com/ts-common/blob/master/.gitignore"`, function () {
+      assert.deepEqual(getGitHubRepositoryFromUrl("https://github.com/ts-common/blob/master/.gitignore"), {
+        organization: "",
+        name: "ts-common",
+      });
     });
   });
 


### PR DESCRIPTION
In openapi-sdk-automation I came across the need to know what repository I was executing a `git` command within. I can't count on the folder name to be the name of the repository (especially since it wouldn't have the organization name), so I needed to be able to get the `remote.origin.url` configuration value. That didn't exist in my `git.ts` file yet, so this PR adds that functionality.