### PR TITLE
Add Command interface to run.ts

### DIFF
--- a/lib/arrays.ts
+++ b/lib/arrays.ts
@@ -9,7 +9,7 @@
  * @param values The array to check.
  * @returns Whether or not the provided array contains any values.
  */
-export function any<T>(values: T[] | undefined): boolean {
+export function any<T>(values: T[] | undefined): values is T[] {
   return !!(values && values.length > 0);
 }
 

--- a/lib/npm.ts
+++ b/lib/npm.ts
@@ -25,7 +25,7 @@ export function npmExecutable(osPlatform?: string): string {
  * @param options The optional arguments that can be added to the NPM command.
  * @returns The result of running the NPM command.
  */
-export function npm(args: string | string[], options?: RunOptions): Promise<RunResult> {
+export function npm(args: string[], options?: RunOptions): Promise<RunResult> {
   const npmCommand: string = npmExecutable();
   return run(npmCommand, args, options);
 }
@@ -36,12 +36,8 @@ export function npm(args: string | string[], options?: RunOptions): Promise<RunR
  * @param options The optional arguments that can be added to the NPM command.
  * @returns The result of running the NPM command.
  */
-export function npmRun(args: string | string[], options?: RunOptions): Promise<RunResult> {
-  if (typeof args === "string") {
-    args = "run " + args;
-  } else {
-    args.unshift("run");
-  }
+export function npmRun(args: string[], options?: RunOptions): Promise<RunResult> {
+  args.unshift("run");
   return npm(args, options);
 }
 
@@ -51,7 +47,7 @@ export function npmRun(args: string | string[], options?: RunOptions): Promise<R
  * @returns The result of running the NPM command.
  */
 export function npmPack(options?: RunOptions): Promise<RunResult> {
-  return npm("pack", options);
+  return npm(["pack"], options);
 }
 
 /**
@@ -80,18 +76,19 @@ export interface NPMInstallOptions extends RunOptions {
  * @returns The result of running the NPM command.
  */
 export function npmInstall(options: NPMInstallOptions = {}): Promise<RunResult> {
-  let command = "install";
+  const args: string[] = ["install"];
   if (options.installSource) {
-    command += ` ${options.installSource}`;
+    args.push(options.installSource);
   }
   if (options.save) {
-    command += " --save";
+    let saveArgument = "--save";
     if (!options.save.startsWith("-")) {
-      command += "-";
+      saveArgument += "-";
     }
-    command += options.save;
+    saveArgument += options.save;
+    args.push(saveArgument);
   }
-  return npm(command, options);
+  return npm(args, options);
 }
 
 /**
@@ -188,7 +185,7 @@ export class NPMScope {
    * @param options The optional arguments that can be added to the NPM command.
    * @returns The result of running the NPM command.
    */
-  public npm(args: string | string[], options?: RunOptions): Promise<RunResult> {
+  public npm(args: string[], options?: RunOptions): Promise<RunResult> {
     return npm(args, {
       ...this.defaultOptions,
       ...options
@@ -201,7 +198,7 @@ export class NPMScope {
    * @param options The optional arguments that can be added to the NPM command.
    * @returns The result of running the NPM command.
    */
-  public run(args: string | string[], options?: RunOptions): Promise<RunResult> {
+  public run(args: string[], options?: RunOptions): Promise<RunResult> {
     return npmRun(args, {
       ...this.defaultOptions,
       ...options,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ts-common/azure-js-dev-tools",
-  "version": "14.0.4",
+  "version": "15.0.0",
   "description": "Developer dependencies for TypeScript related projects",
   "main": "./dist/lib/index.js",
   "types": "./dist/lib/index.d.ts",
@@ -13,6 +13,7 @@
     "tsc:scripts": "tsc -p ./.scripts/tsconfig.json",
     "tslint:scripts": "tslint -p ./.scripts/ -c tslint.json",
     "prepack": "npm install && npm run build",
+    "build-test": "npm run build && npm test",
     "test": "mocha",
     "coverage": "nyc mocha",
     "tsc": "run-p tsc:sources tsc:scripts",

--- a/test/gitTests.ts
+++ b/test/gitTests.ts
@@ -10,7 +10,7 @@ const runPushRemoteBranchTests: boolean = !!findFileInPathSync("github.auth");
 describe("git.ts", function () {
   describe("git()", function () {
     it("with unrecognized command", async function () {
-      const result: RunResult = await git("foo");
+      const result: RunResult = await git(["foo"]);
       assert(result);
       assert.strictEqual(result.exitCode, 1);
       assert.strictEqual(result.stdout, "");
@@ -23,21 +23,21 @@ describe("git.ts", function () {
     it("with no options", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["fetch"], result: expectedResult });
+      runner.set({ executable: "git", args: ["fetch"], result: expectedResult });
       assert.deepEqual(await gitFetch({ runner }), expectedResult);
     });
 
     it("with prune: true", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 3, stdout: "e", stderr: "f" };
-      runner.set({ command: "git", args: ["fetch", "--prune"], result: () => expectedResult });
+      runner.set({ executable: "git", args: ["fetch", "--prune"], result: () => expectedResult });
       assert.deepEqual(await gitFetch({ runner, prune: true }), expectedResult);
     });
 
     it("with prune: false", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 3, stdout: "e", stderr: "f" };
-      runner.set({ command: "git", args: ["fetch"], result: () => expectedResult });
+      runner.set({ executable: "git", args: ["fetch"], result: () => expectedResult });
       assert.deepEqual(await gitFetch({ runner, prune: false }), expectedResult);
     });
   });
@@ -45,7 +45,7 @@ describe("git.ts", function () {
   it("gitMergeOriginMaster()", async function () {
     const runner = new FakeRunner();
     const expectedResult: RunResult = { exitCode: 1, stdout: "a", stderr: "b" };
-    runner.set({ command: "git", args: ["merge", "origin", "master"], result: expectedResult });
+    runner.set({ executable: "git", args: ["merge", "origin", "master"], result: expectedResult });
     assert.deepEqual(await gitMergeOriginMaster({ runner }), expectedResult);
   });
 
@@ -53,14 +53,14 @@ describe("git.ts", function () {
     it("with no options", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["clone", "https://my.fake.git/url"], result: expectedResult });
+      runner.set({ executable: "git", args: ["clone", "https://my.fake.git/url"], result: expectedResult });
       assert.deepEqual(await gitClone("https://my.fake.git/url", { runner }), expectedResult);
     });
 
     it("with all options", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["clone", "--quiet", "--verbose", "--origin", "foo", "--branch", "fake-branch", "--depth", "5", "https://my.fake.git/url", "fake-directory"], result: expectedResult });
+      runner.set({ executable: "git", args: ["clone", "--quiet", "--verbose", "--origin", "foo", "--branch", "fake-branch", "--depth", "5", "https://my.fake.git/url", "fake-directory"], result: expectedResult });
       assert.deepEqual(
         await gitClone("https://my.fake.git/url", {
           runner,
@@ -79,7 +79,7 @@ describe("git.ts", function () {
     it("with no stderr", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "blah", stderr: "" };
-      runner.set({ command: "git", args: ["checkout", "master"], result: expectedResult });
+      runner.set({ executable: "git", args: ["checkout", "master"], result: expectedResult });
       assert.deepEqual(
         await gitCheckout("master", { runner }),
         {
@@ -92,7 +92,7 @@ describe("git.ts", function () {
   it("gitPull()", async function () {
     const runner = new FakeRunner();
     const expectedResult: RunResult = { exitCode: 1, stdout: "a", stderr: "b" };
-    runner.set({ command: "git", args: ["pull"], result: expectedResult });
+    runner.set({ executable: "git", args: ["pull"], result: expectedResult });
     assert.deepEqual(await gitPull({ runner }), expectedResult);
   });
 
@@ -100,51 +100,51 @@ describe("git.ts", function () {
     it("command line arguments with no setUpstream", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["push"], result: expectedResult });
+      runner.set({ executable: "git", args: ["push"], result: expectedResult });
       assert.deepEqual(await gitPush({ runner }), expectedResult);
     });
 
     it("command line arguments with undefined setUpstream", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["push"], result: expectedResult });
+      runner.set({ executable: "git", args: ["push"], result: expectedResult });
       assert.deepEqual(await gitPush({ setUpstream: undefined, runner }), expectedResult);
     });
 
     it("command line arguments with null setUpstream", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["push"], result: expectedResult });
+      runner.set({ executable: "git", args: ["push"], result: expectedResult });
       assert.deepEqual(await gitPush({ setUpstream: undefined, runner }), expectedResult);
     });
 
     it("command line arguments with empty setUpstream", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["push"], result: expectedResult });
+      runner.set({ executable: "git", args: ["push"], result: expectedResult });
       assert.deepEqual(await gitPush({ setUpstream: "", runner }), expectedResult);
     });
 
     it("command line arguments with non-empty setUpstream", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["push", "--set-upstream", "hello", "myfakebranch"], result: expectedResult });
-      runner.set({ command: "git", args: ["branch"], result: { exitCode: 0, stdout: "* myfakebranch" } });
+      runner.set({ executable: "git", args: ["push", "--set-upstream", "hello", "myfakebranch"], result: expectedResult });
+      runner.set({ executable: "git", args: ["branch"], result: { exitCode: 0, stdout: "* myfakebranch" } });
       assert.deepEqual(await gitPush({ setUpstream: "hello", runner }), expectedResult);
     });
 
     it("command line arguments with true setUpstream", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["push", "--set-upstream", "origin", "myfakebranch"], result: expectedResult });
-      runner.set({ command: "git", args: ["branch"], result: { exitCode: 0, stdout: "* myfakebranch" } });
+      runner.set({ executable: "git", args: ["push", "--set-upstream", "origin", "myfakebranch"], result: expectedResult });
+      runner.set({ executable: "git", args: ["branch"], result: { exitCode: 0, stdout: "* myfakebranch" } });
       assert.deepEqual(await gitPush({ setUpstream: true, runner }), expectedResult);
     });
 
     it("command line arguments with true setUpstream", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["push"], result: expectedResult });
+      runner.set({ executable: "git", args: ["push"], result: expectedResult });
       assert.deepEqual(await gitPush({ setUpstream: false, runner }), expectedResult);
     });
 
@@ -298,7 +298,7 @@ describe("git.ts", function () {
   it("gitAddAll()", async function () {
     const runner = new FakeRunner();
     const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-    runner.set({ command: "git", args: ["add", "*"], result: expectedResult });
+    runner.set({ executable: "git", args: ["add", "*"], result: expectedResult });
     assert.deepEqual(await gitAddAll({ runner }), expectedResult);
   });
 
@@ -306,14 +306,14 @@ describe("git.ts", function () {
     it("with one commit message", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["commit", "-m", "Hello World"], result: expectedResult });
+      runner.set({ executable: "git", args: ["commit", "-m", "Hello World"], result: expectedResult });
       assert.deepEqual(await gitCommit("Hello World", { runner }), expectedResult);
     });
 
     it("with two commit messages", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["commit", "-m", "Hello", "-m", "World"], result: expectedResult });
+      runner.set({ executable: "git", args: ["commit", "-m", "Hello", "-m", "World"], result: expectedResult });
       assert.deepEqual(await gitCommit(["Hello", "World"], { runner }), expectedResult);
     });
   });
@@ -322,7 +322,7 @@ describe("git.ts", function () {
     it("command line arguments", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["branch", "-D", "branchToDelete"], result: expectedResult });
+      runner.set({ executable: "git", args: ["branch", "-D", "branchToDelete"], result: expectedResult });
       assert.deepEqual(await gitDeleteLocalBranch("branchToDelete", { runner }), expectedResult);
     });
 
@@ -348,7 +348,7 @@ describe("git.ts", function () {
     it("command line arguments", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["checkout", "-b", "branchToCreate"], result: expectedResult });
+      runner.set({ executable: "git", args: ["checkout", "-b", "branchToCreate"], result: expectedResult });
       assert.deepEqual(await gitCreateLocalBranch("branchToCreate", { runner }), expectedResult);
     });
 
@@ -391,21 +391,21 @@ describe("git.ts", function () {
     it("command line arguments with no provided remoteName", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["push", "origin", ":branchToDelete"], result: expectedResult });
+      runner.set({ executable: "git", args: ["push", "origin", ":branchToDelete"], result: expectedResult });
       assert.deepEqual(await gitDeleteRemoteBranch("branchToDelete", { runner }), expectedResult);
     });
 
     it("command line arguments with undefined remoteName", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["push", "origin", ":branchToDelete"], result: expectedResult });
+      runner.set({ executable: "git", args: ["push", "origin", ":branchToDelete"], result: expectedResult });
       assert.deepEqual(await gitDeleteRemoteBranch("branchToDelete", { remoteName: undefined, runner }), expectedResult);
     });
 
     it("command line arguments with null remoteName", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["push", "origin", ":branchToDelete"], result: expectedResult });
+      runner.set({ executable: "git", args: ["push", "origin", ":branchToDelete"], result: expectedResult });
       // tslint:disable-next-line:no-null-keyword
       assert.deepEqual(await gitDeleteRemoteBranch("branchToDelete", { remoteName: null as any, runner }), expectedResult);
     });
@@ -413,14 +413,14 @@ describe("git.ts", function () {
     it("command line arguments with empty remoteName", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["push", "origin", ":branchToDelete"], result: expectedResult });
+      runner.set({ executable: "git", args: ["push", "origin", ":branchToDelete"], result: expectedResult });
       assert.deepEqual(await gitDeleteRemoteBranch("branchToDelete", { remoteName: "", runner }), expectedResult);
     });
 
     it("command line arguments with provided remoteName", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["push", "fancypants", ":branchToDelete"], result: expectedResult });
+      runner.set({ executable: "git", args: ["push", "fancypants", ":branchToDelete"], result: expectedResult });
       assert.deepEqual(await gitDeleteRemoteBranch("branchToDelete", { remoteName: "fancypants", runner }), expectedResult);
     });
 
@@ -448,7 +448,7 @@ describe("git.ts", function () {
         stderr: "d",
         filesChanged: []
       };
-      runner.set({ command: "git", args: ["diff"], result: expectedResult });
+      runner.set({ executable: "git", args: ["diff"], result: expectedResult });
       assert.deepEqual(await gitDiff({ runner }), expectedResult);
     });
 
@@ -460,7 +460,7 @@ describe("git.ts", function () {
         stderr: "d",
         filesChanged: []
       };
-      runner.set({ command: "git", args: ["diff", "fake-commit1"], result: expectedResult });
+      runner.set({ executable: "git", args: ["diff", "fake-commit1"], result: expectedResult });
       assert.deepEqual(await gitDiff({ runner, commit1: "fake-commit1" }), expectedResult);
     });
 
@@ -472,7 +472,7 @@ describe("git.ts", function () {
         stderr: "d",
         filesChanged: []
       };
-      runner.set({ command: "git", args: ["diff", "fake-commit2"], result: expectedResult });
+      runner.set({ executable: "git", args: ["diff", "fake-commit2"], result: expectedResult });
       assert.deepEqual(await gitDiff({ runner, commit2: "fake-commit2" }), expectedResult);
     });
 
@@ -484,7 +484,7 @@ describe("git.ts", function () {
         stderr: "d",
         filesChanged: []
       };
-      runner.set({ command: "git", args: ["diff", "fake-commit1", "fake-commit2"], result: expectedResult });
+      runner.set({ executable: "git", args: ["diff", "fake-commit1", "fake-commit2"], result: expectedResult });
       assert.deepEqual(await gitDiff({ runner, commit1: "fake-commit1", commit2: "fake-commit2" }), expectedResult);
     });
 
@@ -498,7 +498,7 @@ describe("git.ts", function () {
           joinPath(process.cwd(), "c")
         ]
       };
-      runner.set({ command: "git", args: ["diff", "--name-only"], result: expectedResult });
+      runner.set({ executable: "git", args: ["diff", "--name-only"], result: expectedResult });
       assert.deepEqual(await gitDiff({ runner, nameOnly: true }), expectedResult);
     });
 
@@ -510,7 +510,7 @@ describe("git.ts", function () {
         stderr: "d",
         filesChanged: []
       };
-      runner.set({ command: "git", args: ["diff", "--staged"], result: expectedResult });
+      runner.set({ executable: "git", args: ["diff", "--staged"], result: expectedResult });
       assert.deepEqual(await gitDiff({ runner, staged: true }), expectedResult);
     });
 
@@ -522,7 +522,7 @@ describe("git.ts", function () {
         stderr: "d",
         filesChanged: []
       };
-      runner.set({ command: "git", args: ["diff", "--ignore-all-space"], result: expectedResult });
+      runner.set({ executable: "git", args: ["diff", "--ignore-all-space"], result: expectedResult });
       assert.deepEqual(await gitDiff({ runner, ignoreSpace: "all" }), expectedResult);
     });
 
@@ -534,7 +534,7 @@ describe("git.ts", function () {
         stderr: "d",
         filesChanged: []
       };
-      runner.set({ command: "git", args: ["diff", "--ignore-space-change"], result: expectedResult });
+      runner.set({ executable: "git", args: ["diff", "--ignore-space-change"], result: expectedResult });
       assert.deepEqual(await gitDiff({ runner, ignoreSpace: "change" }), expectedResult);
     });
 
@@ -548,7 +548,7 @@ describe("git.ts", function () {
           joinPath(process.cwd(), "foo.txt")
         ]
       };
-      runner.set({ command: "git", args: ["diff", "--ignore-space-at-eol"], result: expectedResult });
+      runner.set({ executable: "git", args: ["diff", "--ignore-space-at-eol"], result: expectedResult });
       assert.deepEqual(await gitDiff({ runner, ignoreSpace: "at-eol" }), expectedResult);
     });
   });
@@ -565,7 +565,7 @@ describe("git.ts", function () {
           "x"
         ]
       };
-      runner.set({ command: "git branch", result: expectedResult });
+      runner.set({ executable: "git", args: ["branch"], result: expectedResult });
       const branchResult: GitLocalBranchesResult = await gitLocalBranches({ runner });
       assert.deepEqual(branchResult, expectedResult);
     });
@@ -582,7 +582,7 @@ describe("git.ts", function () {
         stdout: "* daschult/gitBranchRemote\n  master\n",
         stderr: "",
       };
-      runner.set({ command: "git branch", result: expectedResult });
+      runner.set({ executable: "git", args: ["branch"], result: expectedResult });
       const branchResult: GitLocalBranchesResult = await gitLocalBranches({ runner });
       assert.deepEqual(branchResult, expectedResult);
     });
@@ -673,7 +673,7 @@ describe("git.ts", function () {
           }
         ],
       };
-      runner.set({ command: "git branch --remotes", result: expectedResult });
+      runner.set({ executable: "git", args: ["branch", "--remotes"], result: expectedResult });
       const branchResult: GitRunResult = await gitRemoteBranches({ runner });
       assert.deepEqual(branchResult, expectedResult);
     });
@@ -691,7 +691,7 @@ describe("git.ts", function () {
           }
         ]
       };
-      runner.set({ command: "git branch --remotes", result: expectedResult });
+      runner.set({ executable: "git", args: ["branch", "--remotes"], result: expectedResult });
       const branchResult: GitRunResult = await gitRemoteBranches({ runner });
       assert.deepEqual(branchResult, expectedResult);
     });
@@ -713,7 +713,7 @@ Changes not staged for commit:
 
 no changes added to commit (use "git add" and/or "git commit -a")`
       };
-      runner.set({ command: "git", args: ["status"], result: expectedResult });
+      runner.set({ executable: "git", args: ["status"], result: expectedResult });
       const statusResult: GitStatusResult = await gitStatus({
         executionFolderPath: "/mock/folder/",
         runner
@@ -745,7 +745,7 @@ no changes added to commit (use "git add" and/or "git commit -a")`
 nothing to commit, working tree clean`,
         stderr: ""
       };
-      runner.set({ command: "git status", result: expectedResult });
+      runner.set({ executable: "git", args: ["status"], result: expectedResult });
       const statusResult: GitStatusResult = await gitStatus({
         runner,
         executionFolderPath: "/mock/folder/"
@@ -788,7 +788,7 @@ Untracked files:
 no changes added to commit (use "git add" and/or "git commit -a")`,
         stderr: ""
       };
-      runner.set({ command: "git", args: ["status"], result: expectedResult });
+      runner.set({ executable: "git", args: ["status"], result: expectedResult });
       const statusResult: GitStatusResult = await gitStatus({
         runner,
         executionFolderPath: "/mock/folder/"
@@ -823,7 +823,7 @@ no changes added to commit (use "git add" and/or "git commit -a")`,
     it("command line arguments", async function () {
       const runner = new FakeRunner();
       const expectedResult: RunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["config", "--get", "a"], result: expectedResult });
+      runner.set({ executable: "git", args: ["config", "--get", "a"], result: expectedResult });
       assert.deepEqual(await gitConfigGet("a", { runner }), expectedResult);
     });
 
@@ -884,7 +884,7 @@ no changes added to commit (use "git add" and/or "git commit -a")`,
     it("command line arguments", async function () {
       const runner = new FakeRunner();
       const expectedResult: GitConfigGetResult = { exitCode: 2, stdout: "c", stderr: "d", configurationValue: "e" };
-      runner.set({ command: "git", args: ["config", "--get", "remote.origin.url"], result: expectedResult });
+      runner.set({ executable: "git", args: ["config", "--get", "remote.origin.url"], result: expectedResult });
       assert.deepEqual(await gitGetRepositoryUrl({ runner }), expectedResult.configurationValue);
     });
 
@@ -904,7 +904,7 @@ no changes added to commit (use "git add" and/or "git commit -a")`,
     it("command line arguments", async function () {
       const runner = new FakeRunner();
       const expectedResult: GitRunResult = { exitCode: 2, stdout: "c", stderr: "d" };
-      runner.set({ command: "git", args: ["reset", "*"], result: expectedResult });
+      runner.set({ executable: "git", args: ["reset", "*"], result: expectedResult });
       assert.strictEqual(await gitResetAll({ runner }), expectedResult);
     });
   });

--- a/test/npmTests.ts
+++ b/test/npmTests.ts
@@ -48,7 +48,7 @@ describe("npm.ts", function () {
 
   describe("npm()", function () {
     it("with unrecognized command", async function () {
-      const result: RunResult = await npm("foo");
+      const result: RunResult = await npm(["foo"]);
       assert(result);
       assert.strictEqual(result.exitCode, 1);
       assertEx.contains(result.stdout, "Usage: npm <command>");
@@ -66,7 +66,7 @@ describe("npm.ts", function () {
         stderr: "d",
         version: "blah",
       } as any;
-      runner.set({ command: npmExecutable(), args: ["view", "--json"], result: expectedResult });
+      runner.set({ executable: npmExecutable(), args: ["view", "--json"], result: expectedResult });
       assert.deepEqual(await npmView({ runner }), expectedResult);
     });
 
@@ -78,11 +78,13 @@ describe("npm.ts", function () {
         stderr: "d",
         version: "blah",
       } as any;
-      runner.set({ command: npmExecutable(), args: ["view", "foo", "--json"], result: expectedResult });
+      runner.set({ executable: npmExecutable(), args: ["view", "foo", "--json"], result: expectedResult });
       assert.deepEqual(await npmView({ packageName: "foo", runner }), expectedResult);
     });
 
     it("with autorest", async function () {
+      this.timeout(10000);
+
       const autorestDetails: NPMViewResult = await npmView({ packageName: "autorest" });
       assertEx.defined(autorestDetails);
       assert.strictEqual(autorestDetails.exitCode, 0);

--- a/test/runTests.ts
+++ b/test/runTests.ts
@@ -1,54 +1,597 @@
 import { assert } from "chai";
 import { assertEx } from "../lib/assertEx";
-import { FakeRunner, RunResult, run } from "../lib/run";
+import { commandToString, ensureQuoted, FakeRunner, parseCommand, parseCommands, parseCommandToken, parseCommandTokens, run, RunResult } from "../lib/run";
 
 describe("run.ts", function () {
+  describe("commandToString()", function () {
+    it("with executable with no spaces", function () {
+      assert.strictEqual(commandToString({ executable: `my.exe` }), `my.exe`);
+    });
+
+    it("with executable with spaces", function () {
+      assert.strictEqual(commandToString({ executable: `my really cool.exe` }), `"my really cool.exe"`);
+    });
+
+    it("with empty args", function () {
+      assert.strictEqual(commandToString({ executable: "a", args: [] }), "a");
+    });
+
+    it("with non-empty args with empty argument values", function () {
+      assert.strictEqual(commandToString({ executable: "a", args: ["", "", ""] }), "a");
+    });
+
+    it("with non-empty args with non-empty argument values with no spaces", function () {
+      assert.strictEqual(commandToString({ executable: "a", args: ["b", "c", "d"] }), "a b c d");
+    });
+
+    it("with non-empty args with non-empty argument values with spaces", function () {
+      assert.strictEqual(commandToString({ executable: "a", args: ["b", "c d", "e f g"] }), `a b "c d" "e f g"`);
+    });
+  });
+
+  describe("ensureQuoted()", function () {
+    describe("with no quote provided", function () {
+      it(`with ""`, function () {
+        assert.strictEqual(ensureQuoted(``), `""`);
+      });
+
+      it(`with " "`, function () {
+        assert.strictEqual(ensureQuoted(` `), `" "`);
+      });
+
+      it(`with "abc"`, function () {
+        assert.strictEqual(ensureQuoted(`abc`), `"abc"`);
+      });
+
+      it(`with ""abc"`, function () {
+        assert.strictEqual(ensureQuoted(`"abc`), `"\\"abc"`);
+      });
+
+      it(`with "abc""`, function () {
+        assert.strictEqual(ensureQuoted(`abc"`), `"abc\\""`);
+      });
+
+      it(`with ""abc""`, function () {
+        assert.strictEqual(ensureQuoted(`"abc"`), `"abc"`);
+      });
+
+      it(`with "'abc"`, function () {
+        assert.strictEqual(ensureQuoted(`'abc`), `"'abc"`);
+      });
+
+      it(`with "abc'"`, function () {
+        assert.strictEqual(ensureQuoted(`abc'`), `"abc'"`);
+      });
+
+      it(`with "'abc'`, function () {
+        assert.strictEqual(ensureQuoted(`'abc'`), `"'abc'"`);
+      });
+    });
+
+    describe("with empty quote provided", function () {
+      it(`with ""`, function () {
+        assert.strictEqual(ensureQuoted(``, ``), ``);
+      });
+
+      it(`with " "`, function () {
+        assert.strictEqual(ensureQuoted(` `, ``), ` `);
+      });
+
+      it(`with "abc"`, function () {
+        assert.strictEqual(ensureQuoted(`abc`, ``), `abc`);
+      });
+
+      it(`with ""abc"`, function () {
+        assert.strictEqual(ensureQuoted(`"abc`, ``), `"abc`);
+      });
+
+      it(`with "abc""`, function () {
+        assert.strictEqual(ensureQuoted(`abc"`, ``), `abc"`);
+      });
+
+      it(`with ""abc""`, function () {
+        assert.strictEqual(ensureQuoted(`"abc"`, ``), `"abc"`);
+      });
+
+      it(`with "'abc"`, function () {
+        assert.strictEqual(ensureQuoted(`'abc`, ``), `'abc`);
+      });
+
+      it(`with "abc'`, function () {
+        assert.strictEqual(ensureQuoted(`abc'`, ``), `abc'`);
+      });
+
+      it(`with "'abc'`, function () {
+        assert.strictEqual(ensureQuoted(`'abc'`, ``), `'abc'`);
+      });
+    });
+
+    describe("with single quote provided", function () {
+      it(`with ""`, function () {
+        assert.strictEqual(ensureQuoted(``, `'`), `''`);
+      });
+
+      it(`with " "`, function () {
+        assert.strictEqual(ensureQuoted(` `, `'`), `' '`);
+      });
+
+      it(`with "abc"`, function () {
+        assert.strictEqual(ensureQuoted(`abc`, `'`), `'abc'`);
+      });
+
+      it(`with ""abc"`, function () {
+        assert.strictEqual(ensureQuoted(`"abc`, `'`), `'"abc'`);
+      });
+
+      it(`with "abc""`, function () {
+        assert.strictEqual(ensureQuoted(`abc"`, `'`), `'abc"'`);
+      });
+
+      it(`with ""abc""`, function () {
+        assert.strictEqual(ensureQuoted(`"abc"`, `'`), `'"abc"'`);
+      });
+
+      it(`with "'abc"`, function () {
+        assert.strictEqual(ensureQuoted(`'abc`, `'`), `'\\'abc'`);
+      });
+
+      it(`with "abc'`, function () {
+        assert.strictEqual(ensureQuoted(`abc'`, `'`), `'abc\\''`);
+      });
+
+      it(`with "'abc'`, function () {
+        assert.strictEqual(ensureQuoted(`'abc'`, `'`), `'abc'`);
+      });
+    });
+
+    describe("with non-quote (a) provided", function () {
+      it(`with ""`, function () {
+        assert.strictEqual(ensureQuoted(``, `a`), `aa`);
+      });
+
+      it(`with " "`, function () {
+        assert.strictEqual(ensureQuoted(` `, `a`), `a a`);
+      });
+
+      it(`with "abc"`, function () {
+        assert.strictEqual(ensureQuoted(`abc`, `a`), `aabca`);
+      });
+
+      it(`with ""abc"`, function () {
+        assert.strictEqual(ensureQuoted(`"abc`, `a`), `a"abca`);
+      });
+
+      it(`with "abc""`, function () {
+        assert.strictEqual(ensureQuoted(`abc"`, `a`), `aabc"a`);
+      });
+
+      it(`with ""abc""`, function () {
+        assert.strictEqual(ensureQuoted(`"abc"`, `a`), `a"abc"a`);
+      });
+
+      it(`with "'abc"`, function () {
+        assert.strictEqual(ensureQuoted(`'abc`, `a`), `a'abca`);
+      });
+
+      it(`with "abc'"`, function () {
+        assert.strictEqual(ensureQuoted(`abc'`, `a`), `aabc'a`);
+      });
+
+      it(`with "'abc'"`, function () {
+        assert.strictEqual(ensureQuoted(`'abc'`, `a`), `a'abc'a`);
+      });
+
+      it(`with "abca"`, function () {
+        assert.strictEqual(ensureQuoted(`abca`, `a`), `abca`);
+      });
+    });
+  });
+
+  describe("parseCommandToken()", function () {
+    it(`with "" and -1`, function () {
+      assert.strictEqual(parseCommandToken(``, -1), undefined);
+    });
+
+    it(`with "" and 0`, function () {
+      assert.strictEqual(parseCommandToken(``, 0), undefined);
+    });
+
+    it(`with "" and 1`, function () {
+      assert.strictEqual(parseCommandToken(``, 1), undefined);
+    });
+
+    it(`with "   " and -1`, function () {
+      assert.strictEqual(parseCommandToken(`   `, -1), undefined);
+    });
+
+    it(`with "   " and 0`, function () {
+      assert.deepEqual(parseCommandToken(`   `, 0), {
+        text: "   ",
+        startIndex: 0,
+        endIndex: 3,
+        isWhitespace: true,
+      });
+    });
+
+    it(`with "   " and 1`, function () {
+      assert.deepEqual(parseCommandToken(`   `, 1), {
+        text: "  ",
+        startIndex: 1,
+        endIndex: 3,
+        isWhitespace: true,
+      });
+    });
+
+    it(`with "   " and 3`, function () {
+      assert.strictEqual(parseCommandToken(`   `, 3), undefined);
+    });
+
+    it(`with "ab" and -1`, function () {
+      assert.strictEqual(parseCommandToken(`ab`, -1), undefined);
+    });
+
+    it(`with "ab" and 0`, function () {
+      assert.deepEqual(parseCommandToken(`ab`, 0), {
+        text: "ab",
+        startIndex: 0,
+        endIndex: 2,
+      });
+    });
+
+    it(`with "ab" and 1`, function () {
+      assert.deepEqual(parseCommandToken(`ab`, 1), {
+        text: "b",
+        startIndex: 1,
+        endIndex: 2,
+      });
+    });
+
+    it(`with "ab" and 2`, function () {
+      assert.strictEqual(parseCommandToken(`ab`, 2), undefined);
+    });
+
+    it(`with "a b " and -1`, function () {
+      assert.strictEqual(parseCommandToken(`a b `, -1), undefined);
+    });
+
+    it(`with "a b " and 0`, function () {
+      assert.deepEqual(parseCommandToken(`a b `, 0), {
+        text: "a",
+        startIndex: 0,
+        endIndex: 1,
+      });
+    });
+
+    it(`with "a b " and 1`, function () {
+      assert.deepEqual(parseCommandToken(`a b `, 1), {
+        text: " ",
+        startIndex: 1,
+        endIndex: 2,
+        isWhitespace: true,
+      });
+    });
+
+    it(`with "a b " and 4`, function () {
+      assert.strictEqual(parseCommandToken(`a b `, 4), undefined);
+    });
+
+    it(`with "'a b '" and -1`, function () {
+      assert.strictEqual(parseCommandToken(`'a b '`, -1), undefined);
+    });
+
+    it(`with "'a b " and 0`, function () {
+      assert.deepEqual(parseCommandToken(`'a b `, 0), {
+        text: "'a b ",
+        startIndex: 0,
+        endIndex: 5,
+      });
+    });
+
+    it(`with "'a b '" and 0`, function () {
+      assert.deepEqual(parseCommandToken(`'a b '`, 0), {
+        text: "'a b '",
+        startIndex: 0,
+        endIndex: 6,
+      });
+    });
+
+    it(`with "'a b \\' c" and 0`, function () {
+      assert.deepEqual(parseCommandToken(`'a b \\' c`, 0), {
+        text: "'a b \\' c",
+        startIndex: 0,
+        endIndex: 9,
+      });
+    });
+
+    it(`with "'a b \\' c' d" and 0`, function () {
+      assert.deepEqual(parseCommandToken(`'a b \\' c' d`, 0), {
+        text: "'a b \\' c'",
+        startIndex: 0,
+        endIndex: 10,
+      });
+    });
+
+    it(`with "'a b '" and 1`, function () {
+      assert.deepEqual(parseCommandToken(`'a b '`, 1), {
+        text: "a",
+        startIndex: 1,
+        endIndex: 2,
+      });
+    });
+
+    it(`with "'a b '" and 6`, function () {
+      assert.strictEqual(parseCommandToken(`'a b '`, 6), undefined);
+    });
+
+    it(`with "--args='a',b,'c d'" and 0`, function () {
+      assert.deepEqual(parseCommandToken(`--args='a',b,'c d'`, 0), {
+        text: "--args='a',b,'c d'",
+        startIndex: 0,
+        endIndex: 18,
+      });
+    });
+  });
+
+  describe("parseCommandTokens()", function () {
+    it(`with ""`, function () {
+      assert.deepEqual(parseCommandTokens(""), []);
+    });
+
+    it(`with "    "`, function () {
+      assert.deepEqual(parseCommandTokens("    "), []);
+    });
+
+    it(`with "a"`, function () {
+      assert.deepEqual(parseCommandTokens("a"), [
+        {
+          text: "a",
+          startIndex: 0,
+          endIndex: 1,
+        }
+      ]);
+    });
+
+    it(`with "a b 'c' 'd e'"`, function () {
+      assert.deepEqual(parseCommandTokens("a b 'c' 'd e'"), [
+        {
+          text: "a",
+          startIndex: 0,
+          endIndex: 1,
+        },
+        {
+          text: "b",
+          startIndex: 2,
+          endIndex: 3,
+        },
+        {
+          text: "'c'",
+          startIndex: 4,
+          endIndex: 7,
+        },
+        {
+          text: "'d e'",
+          startIndex: 8,
+          endIndex: 13,
+        }
+      ]);
+    });
+  });
+
+  describe("parseCommand()", function () {
+    it(`with ""`, function () {
+      assert.strictEqual(parseCommand(""), undefined);
+    });
+
+    it(`with "    "`, function () {
+      assert.strictEqual(parseCommand("    "), undefined);
+    });
+
+    it(`with "a"`, function () {
+      assert.deepEqual(parseCommand("a"), {
+        executable: "a",
+        args: [],
+      });
+    });
+
+    it(`with "a b 'c' 'd e'"`, function () {
+      assert.deepEqual(parseCommand("a b 'c' 'd e'"), {
+        executable: "a",
+        args: [
+          "b",
+          "'c'",
+          "'d e'",
+        ]
+      });
+    });
+
+    it(`with "a b & 'c' 'd e'"`, function () {
+      assert.deepEqual(parseCommand("a b & 'c' 'd e'"), {
+        executable: "a",
+        args: [
+          "b",
+          "&",
+          "'c'",
+          "'d e'",
+        ]
+      });
+    });
+
+    it(`with "a b && 'c' 'd e'"`, function () {
+      assert.deepEqual(parseCommand("a b && 'c' 'd e'"), {
+        executable: "a",
+        args: [
+          "b",
+          "&&",
+          "'c'",
+          "'d e'",
+        ]
+      });
+    });
+
+    it(`with "a b || 'c' 'd e'"`, function () {
+      assert.deepEqual(parseCommand("a b || 'c' 'd e'"), {
+        executable: "a",
+        args: [
+          "b",
+          "||",
+          "'c'",
+          "'d e'",
+        ]
+      });
+    });
+  });
+
+  describe("parseCommands()", function () {
+    it(`with ""`, function () {
+      assert.deepEqual(parseCommands(""), []);
+    });
+
+    it(`with "    "`, function () {
+      assert.deepEqual(parseCommands("    "), []);
+    });
+
+    it(`with "a"`, function () {
+      assert.deepEqual(parseCommands("a"), [
+        {
+          executable: "a",
+          args: [],
+        }
+      ]);
+    });
+
+    it(`with "a b 'c' 'd e'"`, function () {
+      assert.deepEqual(parseCommands("a b 'c' 'd e'"), [
+        {
+          executable: "a",
+          args: [
+            "b",
+            "'c'",
+            "'d e'",
+          ]
+        }
+      ]);
+    });
+
+    it(`with "a b & 'c' 'd e'"`, function () {
+      assert.deepEqual(parseCommands("a b & 'c' 'd e'"), [
+        {
+          executable: "a",
+          args: [
+            "b",
+          ]
+        },
+        {
+          executable: "'c'",
+          args: [
+            "'d e'"
+          ]
+        }
+      ]);
+    });
+
+    it(`with "a b && 'c' 'd e'"`, function () {
+      assert.deepEqual(parseCommands("a b && 'c' 'd e'"), [
+        {
+          executable: "a",
+          args: [
+            "b",
+          ]
+        },
+        {
+          executable: "'c'",
+          args: [
+            "'d e'",
+          ]
+        }
+      ]);
+    });
+
+    it(`with "a b || 'c' 'd e'"`, function () {
+      assert.deepEqual(parseCommands("a b || 'c' 'd e'"), [
+        {
+          executable: "a",
+          args: [
+            "b",
+            "||",
+            "'c'",
+            "'d e'",
+          ]
+        }
+      ]);
+    });
+
+    it(`with "& && & &&"`, function () {
+      assert.deepEqual(parseCommands("& && & &&"), []);
+    });
+
+    it(`with "a & b && 'c' & 'd e'"`, function () {
+      assert.deepEqual(parseCommands("a & b && 'c' & 'd e'"), [
+        {
+          executable: "a",
+          args: []
+        },
+        {
+          executable: "b",
+          args: []
+        },
+        {
+          executable: "'c'",
+          args: []
+        },
+        {
+          executable: "'d e'",
+          args: []
+        }
+      ]);
+    });
+  });
+
   describe("FakeRunner", function () {
     describe("run()", function () {
       it("with no registered result and single string arg", async function () {
         const runner = new FakeRunner();
-        const error: Error = await assertEx.throwsAsync(runner.run("git", "status"));
+        const error: Error = await assertEx.throwsAsync(runner.run({ executable: "git", args: ["status"] }));
         assert.strictEqual(error.message, `No FakeRunner result has been registered for the command "git status" at "${process.cwd()}".`);
       });
 
       it("with registered result and args array", async function () {
         const runner = new FakeRunner();
         const registeredResult: RunResult = { exitCode: 1, stdout: "a", stderr: "b" };
-        runner.set({ command: "git fetch --prune", result: registeredResult });
-        const result: RunResult = await runner.run("git", ["fetch", "--prune"]);
+        runner.set({ executable: "git", args: ["fetch", "--prune"], result: registeredResult });
+        const result: RunResult = await runner.run({ executable: "git", args: ["fetch", "--prune"] });
         assert.deepEqual(result, registeredResult);
       });
 
       it("with undefined registered result", async function () {
         const runner = new FakeRunner();
-        runner.set({ command: "git fetch --prune" });
-        const result: RunResult = await runner.run("git", ["fetch", "--prune"]);
+        runner.set({ executable: "git", args: ["fetch", "--prune"] });
+        const result: RunResult = await runner.run({ executable: "git", args: ["fetch", "--prune"] });
         assert.deepEqual(result, { exitCode: 0 });
       });
 
       it("with passthrough command", async function () {
         const innerRunner = new FakeRunner();
         const registeredResult: RunResult = { exitCode: 1, stdout: "a", stderr: "b" };
-        innerRunner.set({ command: "git fetch --prune", result: registeredResult });
+        innerRunner.set({ executable: "git", args: ["fetch", "--prune"], result: registeredResult });
 
         const runner = new FakeRunner(innerRunner);
-        runner.passthrough("git fetch --prune");
+        runner.passthrough({ executable: "git", args: ["fetch", "--prune"] });
 
-        const result: RunResult = await runner.run("git", ["fetch", "--prune"]);
+        const result: RunResult = await runner.run({ executable: "git", args: ["fetch", "--prune"] });
         assert.deepEqual(result, registeredResult);
       });
 
       it("with registered command with different executionFolderPath", async function () {
         const runner = new FakeRunner();
-        runner.set({ command: "fake-command", executionFolderPath: "/a/b/c" });
-        const error: Error = await assertEx.throwsAsync(runner.run("fake-command", []));
+        runner.set({ executable: "fake-command", executionFolderPath: "/a/b/c" });
+        const error: Error = await assertEx.throwsAsync(runner.run({ executable: "fake-command", args: [] }));
         assert.strictEqual(error.message, `No FakeRunner result has been registered for the command "fake-command" at "${process.cwd()}".`);
       });
 
       it("with registered command with same executionFolderPath", async function () {
         const runner = new FakeRunner();
-        runner.set({ command: "fake-command", executionFolderPath: "/a/b/c", result: { exitCode: 2 } });
-        const result: RunResult = await runner.run("fake-command", [], { executionFolderPath: "/a/b/c" });
+        runner.set({ executable: "fake-command", executionFolderPath: "/a/b/c", result: { exitCode: 2 } });
+        const result: RunResult = await runner.run({ executable: "fake-command", args: [] }, { executionFolderPath: "/a/b/c" });
         assert.deepEqual(result, {
           exitCode: 2
         });
@@ -56,9 +599,9 @@ describe("run.ts", function () {
 
       it("with multiple registered commands", async function () {
         const runner = new FakeRunner();
-        runner.set({ command: "fake-command", result: { exitCode: 2 } });
-        runner.set({ command: "fake-command", result: { exitCode: 3 } });
-        const result: RunResult = await runner.run("fake-command");
+        runner.set({ executable: "fake-command", result: { exitCode: 2 } });
+        runner.set({ executable: "fake-command", result: { exitCode: 3 } });
+        const result: RunResult = await runner.run({ executable: "fake-command" });
         assert.deepEqual(result, {
           exitCode: 3
         });
@@ -68,7 +611,7 @@ describe("run.ts", function () {
         const runner = new FakeRunner();
         runner.passthroughUnrecognized();
 
-        const result: RunResult = await runner.run("git", ["fetch", "--prune"]);
+        const result: RunResult = await runner.run({ executable: "git", args: ["fetch", "--prune"] });
         assertEx.defined(result, "result");
         assertEx.defined(result.processId, "result.processId");
         assert.strictEqual(result.exitCode, 0);


### PR DESCRIPTION
The biggest part of this PR is to create the `parseCommands()` function. In [Azure/azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs) there are some readme.md files that contain `after_scripts` lines with multiple commands on the same line (such as `a && b`). This wasn't working with my previous command parsing logic, so I rewrote the logic and put it into this repository.